### PR TITLE
Fixed finding mesh packages

### DIFF
--- a/velodyne_description/urdf/HDL-32E.urdf.xacro
+++ b/velodyne_description/urdf/HDL-32E.urdf.xacro
@@ -19,7 +19,7 @@
       </inertial>
       <visual>
         <geometry>
-          <mesh filename="$(find velodyne_description)/meshes/HDL32E_base.dae" />
+          <mesh filename="file://$(find velodyne_description)/meshes/HDL32E_base.dae" />
         </geometry>
       </visual>
       <collision>
@@ -45,7 +45,7 @@
       <visual>
         <origin xyz="0 0 -0.09081" rpy="0 0 0" />
         <geometry>
-          <mesh filename="$(find velodyne_description)/meshes/HDL32E_scan.dae" />
+          <mesh filename="file://$(find velodyne_description)/meshes/HDL32E_scan.dae" />
         </geometry>
       </visual>
     </link>

--- a/velodyne_description/urdf/HDL-32E.urdf.xacro
+++ b/velodyne_description/urdf/HDL-32E.urdf.xacro
@@ -19,7 +19,7 @@
       </inertial>
       <visual>
         <geometry>
-          <mesh filename="package://velodyne_description/meshes/HDL32E_base.dae" />
+          <mesh filename="$(find velodyne_description)/meshes/HDL32E_base.dae" />
         </geometry>
       </visual>
       <collision>
@@ -45,7 +45,7 @@
       <visual>
         <origin xyz="0 0 -0.09081" rpy="0 0 0" />
         <geometry>
-          <mesh filename="package://velodyne_description/meshes/HDL32E_scan.dae" />
+          <mesh filename="$(find velodyne_description)/meshes/HDL32E_scan.dae" />
         </geometry>
       </visual>
     </link>

--- a/velodyne_description/urdf/VLP-16.urdf.xacro
+++ b/velodyne_description/urdf/VLP-16.urdf.xacro
@@ -17,12 +17,12 @@
       </inertial>
       <visual>
         <geometry>
-          <mesh filename="$(find velodyne_description)/meshes/VLP16_base_1.dae"/>
+          <mesh filename="file://$(find velodyne_description)/meshes/VLP16_base_1.dae"/>
         </geometry>
       </visual>
       <visual>
         <geometry>
-          <mesh filename="$(find velodyne_description)/meshes/VLP16_base_2.dae"/>
+          <mesh filename="file://$(find velodyne_description)/meshes/VLP16_base_2.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -48,7 +48,7 @@
       <visual>
         <origin xyz="0 0 -0.0377"/>
         <geometry>
-          <mesh filename="$(find velodyne_description)/meshes/VLP16_scan.dae"/>
+          <mesh filename="file://$(find velodyne_description)/meshes/VLP16_scan.dae"/>
         </geometry>
       </visual>
     </link>

--- a/velodyne_description/urdf/VLP-16.urdf.xacro
+++ b/velodyne_description/urdf/VLP-16.urdf.xacro
@@ -17,12 +17,12 @@
       </inertial>
       <visual>
         <geometry>
-          <mesh filename="package://velodyne_description/meshes/VLP16_base_1.dae"/>
+          <mesh filename="$(find velodyne_description)/meshes/VLP16_base_1.dae"/>
         </geometry>
       </visual>
       <visual>
         <geometry>
-          <mesh filename="package://velodyne_description/meshes/VLP16_base_2.dae"/>
+          <mesh filename="$(find velodyne_description)/meshes/VLP16_base_2.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -48,7 +48,7 @@
       <visual>
         <origin xyz="0 0 -0.0377"/>
         <geometry>
-          <mesh filename="package://velodyne_description/meshes/VLP16_scan.dae"/>
+          <mesh filename="$(find velodyne_description)/meshes/VLP16_scan.dae"/>
         </geometry>
       </visual>
     </link>

--- a/velodyne_description/urdf/VLP-32C.urdf.xacro
+++ b/velodyne_description/urdf/VLP-32C.urdf.xacro
@@ -18,12 +18,12 @@
       </inertial>
       <visual>
         <geometry>
-          <mesh filename="$(find velodyne_description)/meshes/VLP16_base_1.dae"/>
+          <mesh filename="file://$(find velodyne_description)/meshes/VLP16_base_1.dae"/>
         </geometry>
       </visual>
       <visual>
         <geometry>
-          <mesh filename="$(find velodyne_description)/meshes/VLP16_base_2.dae"/>
+          <mesh filename="file://$(find velodyne_description)/meshes/VLP16_base_2.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -49,7 +49,7 @@
       <visual>
         <origin xyz="0 0 -0.0377"/>
         <geometry>
-          <mesh filename="$(find velodyne_description)/meshes/VLP16_scan.dae"/>
+          <mesh filename="file://$(find velodyne_description)/meshes/VLP16_scan.dae"/>
         </geometry>
       </visual>
     </link>

--- a/velodyne_description/urdf/VLP-32C.urdf.xacro
+++ b/velodyne_description/urdf/VLP-32C.urdf.xacro
@@ -18,12 +18,12 @@
       </inertial>
       <visual>
         <geometry>
-          <mesh filename="package://velodyne_description/meshes/VLP16_base_1.dae"/>
+          <mesh filename="$(find velodyne_description)/meshes/VLP16_base_1.dae"/>
         </geometry>
       </visual>
       <visual>
         <geometry>
-          <mesh filename="package://velodyne_description/meshes/VLP16_base_2.dae"/>
+          <mesh filename="$(find velodyne_description)/meshes/VLP16_base_2.dae"/>
         </geometry>
       </visual>
       <collision>
@@ -49,7 +49,7 @@
       <visual>
         <origin xyz="0 0 -0.0377"/>
         <geometry>
-          <mesh filename="package://velodyne_description/meshes/VLP16_scan.dae"/>
+          <mesh filename="$(find velodyne_description)/meshes/VLP16_scan.dae"/>
         </geometry>
       </visual>
     </link>


### PR DESCRIPTION
Before I made this change, Gazebo wouldn't find the meshes for the sensors, causing to not load when the sensor is enabled most of the time. This change makes it so the package can be found on Foxy. I'm not certain if this issue is present on other ROS2 distros.